### PR TITLE
Remove unnecessary DRUPAL_VERSION setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,7 @@ services:
 
   app:
     image: wodby/drupal-php:7.0 # Allowed: 7.0, 5.6
-    environment:
-      DRUPAL_VERSION: 8 # Allowed: 7, 8
+#    environment:
 #      XDEBUG_CONFIG: xdebug.remote_autostart=1
     links:
       - db


### PR DESCRIPTION
Deadcode elimination. Should be applied only with https://github.com/Wodby/drupal-nginx/pull/2