### PR TITLE
Remove mounted volume for mariadb to avoid permissions issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal
 #    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci # The simple way to override the mariadb config.
-    volumes:
-      - ./docker-runtime/mariadb:/var/lib/mysql
+#   volumes:
+#      - ./docker-runtime/mariadb:/var/lib/mysql # If you wish to keep your database even if container volumes are removed, uncomment this line.
 #      - ./docker-runtime/mariadb-init:/docker-entrypoint-initdb.d # Place init .sql file(s) here.
 
   php:


### PR DESCRIPTION
I was unable to launch the cluster right out of the box.  I'm on fedora with native docker.

My user is in the docker group, so I don't use sudo for docker or docker-compose.

`docker-compose up` created the `docker-runtime` folder but it was owned by root.

Then I got the following errors from the mariadb_1 container: 

```
mariadb_1  | Initializing database
mariadb_1  | chown: /var/lib/mysql/: Permission denied
mariadb_1  | Cannot change ownership of the database directories to the 'mysql'
mariadb_1  | user.  Check that you have the necessary permissions and try again.
```

I use a lot of database containers, rarely do I set a volume. Docker's automatic volume creation is good enough by default, I think, so I commented out the volumes and added a note about keeping your MySQL files around if you want to.