### PR TITLE
Mac OS X settings for Xdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,34 @@ $ docker-compose exec --user 82 php drupal list
 
 #### Xdebug
 
-If you want to use xdebug, enable the following option in the compose file:
+If you want to use Xdebug, uncomment this line to enable it in the compose file before starting containers:
 
 ```yml
-PHP_XDEBUG_ENABLED: 0 # Set 1 to enable.
+PHP_XDEBUG_ENABLED: 1       # Comment out to disable (default).
 ```
 
-See the <a href="https://github.com/Wodby/drupal-php/issues/1" target="_blank">known issue</a> with Xdebug in Mac OS.
+If you would like to autostart Xdebug, uncomment this line:
+
+```yml
+PHP_XDEBUG_AUTOSTART: 1     # Comment out to disable (default).
+```
+
+#### Xdebug on Mac OS X
+
+There are two more things that need to be done on Mac OS X in order to have Xdebug working. Uncomment `PHP_XDEBUG_ENABLED` to enable Xdebug and uncomment the following two lines:
+
+```yml
+PHP_XDEBUG_REMOTE_CONNECT_BACK: 0         # Disabled for remote.host to work (enabled by default)
+PHP_XDEBUG_REMOTE_HOST: "10.254.254.254"  # Setting the host (localhost by default)
+```
+
+It is also needed to have localhost loopback alias with IP from above. You need this only once and that settings stays active until logout or restart.
+
+```bash
+sudo ifconfig lo0 alias 10.254.254.254
+```
+
+For more details see the issue with <a href="https://github.com/Wodby/drupal-php/issues/1" target="_blank">Xdebug in Mac OS</a>.
 
 ### MariaDB
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,10 @@ services:
       PHP_HOST_NAME: localhost:8000
 #      PHP_DOCROOT: public # Relative path inside the /var/www/html/ directory.
       PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
-      PHP_XDEBUG_ENABLED: 0 # Set 1 to enable.
-      PHP_XDEBUG_AUTOSTART: 1
-      PHP_XDEBUG_REMOTE_CONNECT_BACK: 1
-      PHP_XDEBUG_REMOTE_HOST: "localhost"
+      # PHP_XDEBUG_ENABLED: 1
+      # PHP_XDEBUG_AUTOSTART: 1
+      # PHP_XDEBUG_REMOTE_CONNECT_BACK: 0         # This is needed to respect remote.host setting bellow
+      # PHP_XDEBUG_REMOTE_HOST: "10.254.254.254"  # You will also need to 'sudo ifconfig lo0 alias 10.254.254.254'
     volumes:
       - ./:/var/www/html
 


### PR DESCRIPTION
Included commented out settings for Xdebug for Mac OS X, updated instructions in README.md. This solves Wodby/drupal-php#1