### PR TITLE
Add instructions for viewing logs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,11 @@ docker-compose ps
 
 10\. That's it! You drupal website should be up and running at http://localhost:8000.
 
+You can view your access and error logs by running:
+```bash
+docker-compose logs
+```
+
 You can stop all containers by executing:
 
 ```bash


### PR DESCRIPTION
As someone who is new to docker it took me and embarassingly long time to figure out that all the logs were being forwarded to STDOUT. And then it took me a slightly less embarassingly (but still embnarassingly) long amount of time to realize that ```docker-compose logs``` displayed STDOUT. I propse a quick note like this in the docs to save the next guy/gal the headache.