### PR TITLE
drop unnecessary or undocumented web folder of NGINX_SERVER_ROOT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       NGINX_STATIC_CONTENT_OPEN_FILE_CACHE: "off"
       NGINX_ERROR_LOG_LEVEL: debug
       NGINX_BACKEND_HOST: php
-      NGINX_SERVER_ROOT: /var/www/html/web
+      NGINX_SERVER_ROOT: /var/www/html
     volumes:
       - codebase:/var/www/html
 #      - docker-sync:/var/www/html # Docker-sync for macOS users


### PR DESCRIPTION
"Update nginx and php volumes to - ./:/var/www/html to mount your codebase", but commonly docker-compose.yml files are inside root and Drupal itself does not provide a ´web´ folder