### PR TITLE
Update redis.md

### DIFF
--- a/docs/containers/redis.md
+++ b/docs/containers/redis.md
@@ -27,7 +27,7 @@ $conf['redis_client_port'] = '6379';
 DRUPAL 8:
 
 ```php
-$contrib_path = is_dir('sites/all/modules/contrib') ? 'sites/all/modules/contrib' : 'sites/all/modules';
+$contrib_path = is_dir('modules/contrib') ? 'modules/contrib' : 'modules';
 
 $settings['redis.connection']['host'] = 'redis';
 $settings['redis.connection']['port'] = '6379';


### PR DESCRIPTION
Drupal 8 no more follows sites/all/module path. module folder has moved to docroot.