### PR TITLE
Adds command for portainer to locate local Docker socket

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,7 @@ services:
 
   portainer:
     image: portainer/portainer
-    command: --no-auth
+    command: --no-auth -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:


### PR DESCRIPTION
Adds an command option to locate the unix socket for the local Docker instance

Fixes issue: #189 