### PR TITLE
Added port settings to the Solr config.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,8 @@ services:
 ##    image: wodby/drupal-solr:8-6.3-2.2.0
 ##    image: wodby/drupal-solr:8-5.5-2.2.0
 ##    image: wodby/drupal-solr:7-5.4-2.2.0
+#    ports:
+#     - "8983:8983"
 #    environment:
 #      SOLR_HEAP: 1024m
 #    labels:


### PR DESCRIPTION
When I tried to use solr by just uncommenting the settings inside, it didn't work, it requires port settings. I don't know if I did something wrong with traefik, but this fixed the problem for me, and solr works on the set port now.