### PR TITLE
Added containers for selenium-hub and chome for Behat testing.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -235,6 +235,23 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
+  selenium-hub:
+    image: selenium/hub
+    ports:
+      - "4444:4444"
+
+  chrome:
+    image: selenium/node-chrome-debug
+    ports:
+    - "5900:5900"
+    links:
+      - selenium-hub:hub
+    volumes:
+      - /dev/shm:/dev/shm # Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952
+    environment:
+        HUB_PORT_4444_TCP_ADDR: selenium-hub
+        HUB_PORT_4444_TCP_PORT: 4444
+
 #volumes:
 ## Docker-sync for macOS users
 #  docker-sync:


### PR DESCRIPTION
Selenium-hub and a browser make behat testing possible in a local docker container. Please consider incorporating these containers in the dockerfile.