### PR TITLE
Add OS-agnostic xdebug remote host IP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,10 @@ services:
 #      PHP_XDEBUG_DEFAULT_ENABLE: 1
 #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
 #      PHP_IDE_CONFIG: serverName=my-ide
-#      PHP_XDEBUG_REMOTE_HOST: 172.17.0.1 # Linux
-#      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254 # macOS
-#      PHP_XDEBUG_REMOTE_HOST: 10.0.75.1 # Windows
+#      PHP_XDEBUG_REMOTE_HOST: host.docker.internal # Docker 18.03+ & Linux/Mac/Win
+#      PHP_XDEBUG_REMOTE_HOST: 172.17.0.1 # Linux, Docker < 18.03
+#      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254 # macOS, Docker < 18.03
+#      PHP_XDEBUG_REMOTE_HOST: 10.0.75.1 # Windows, Docker < 18.03
     volumes:
       - ./:/var/www/html
 ## For macOS users (https://wodby.com/stacks/drupal/docs/local/docker-for-mac/)


### PR DESCRIPTION
As of Docker 18.03, there is a consistent IP address for the host machine, which works on all OSes. From https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds:

> I WANT TO CONNECT FROM A CONTAINER TO A SERVICE ON THE HOST
The host has a changing IP address (or none if you have no network access). From 18.03 onwards our recommendation is to connect to the special DNS name host.docker.internal, which resolves to the internal IP address used by the host.

This is a large improvement for Mac users, since they no longer have to do anything with loopback addresses as documented on https://wodby.com/stacks/drupal/docs/local/xdebug/#macos

Other than that, it would mostly just simplify the xdebug usage steps across OSes.

I'm not sure about the project's policy for requiring specific Docker versions, so I have only added this stuff as an option, rather than a default, both in terms of code and documentation. I hope that once a certain time window passes it could be assumed or required that users have Docker 18.03+, at which point the code and documentation for legacy Docker users could be removed.

Testing: I tested this on Mac OS, Docker CE 18.03.0-ce-mac60 (23751). Unfortunately I don' t currently have the means to test it on Linux/Windows.

I updated the respective documentation in https://github.com/wodby/drupal-docs/pull/3.