### PR TITLE
Fix version typo in .env

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@
 ### [STABILITY_TAG] is a version of image (not application)
 ### [STABILITY_TAG] correspond to git tag of corresponding image repository
 ###
-### EXAMPLE: wodby/mariadb:10.2-3.1.2 has MariaDB 10.2 and stability tag 3.0.2
+### EXAMPLE: wodby/mariadb:10.2-3.1.2 has MariaDB 10.2 and stability tag 3.1.2
 ### New stability tags include patch updates for applications and other fixes/improvements
 ### Changelog for stability tag can be found at https://github.com/wodby/mariadb/releases
 ###


### PR DESCRIPTION
But idk why GitHub is added new line even if it not presented. 🤷‍