### PR TITLE
Set 80 columns for docker exec -it bash sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       DB_PASSWORD: $DB_PASSWORD
       DB_NAME: $DB_NAME
       DB_DRIVER: $DB_DRIVER
+      COLUMNS: 80 # Set 80 columns for docker exec -it.
 ## Read instructions at https://wodby.com/stacks/drupal/docs/local/xdebug/
 #      PHP_XDEBUG: 1
 #      PHP_XDEBUG_DEFAULT_ENABLE: 1


### PR DESCRIPTION
Relates to #227 

I confirmed that this resolves the issue when accessing the container in interactive mode.

```
$ docker exec -it php /bin/bash
wodby@php.container:/var/www/html $ drush --version
Drush Launcher Version: 0.6.0
 Drush Version   :  8.1.17
```