### PR TITLE
Change hardcoded traefik.backend setting to dynamic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 #      - ./:/var/www/html:cached # User-guided caching
 #      - docker-sync:/var/www/html # Docker-sync
     labels:
-      - 'traefik.backend=nginx'
+      - 'traefik.backend=${PROJECT_NAME}_nginx'
       - 'traefik.port=80'
       - 'traefik.frontend.rule=Host:${PROJECT_BASE_URL}'
 


### PR DESCRIPTION
Per issue here, I provide a patch that solves this, so you can run multiple d4d projects even without using traefik.yml file on the same machine.

https://github.com/wodby/docker4drupal/issues/342