### PR TITLE
[Fix] multiple projects drush exec conflict

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -28,7 +28,7 @@ shell:
 	docker exec -ti -e COLUMNS=$(shell tput cols) -e LINES=$(shell tput lines) $(shell docker ps --filter name='$(PROJECT_NAME)_php' --format "{{ .ID }}") sh
 
 drush:
-	docker exec $(shell docker ps --filter name='$(PROJECT_NAME)_php' --format "{{ .ID }}") drush -r $(DRUPAL_ROOT) $(filter-out $@,$(MAKECMDGOALS))
+	docker exec $(shell docker ps --filter name='^/$(PROJECT_NAME)_php' --format "{{ .ID }}") drush -r $(DRUPAL_ROOT) $(filter-out $@,$(MAKECMDGOALS))
 
 logs:
 	@docker-compose logs -f $(filter-out $@,$(MAKECMDGOALS))


### PR DESCRIPTION
Fix conflict when we have 2 projects with almost same name
exemple: `my_project` and `oldmy_project`

`--filter name=` don't search exact name that why we need to specify the container name start with project name with regex `^/`