### PR TITLE
Enable Drupal Multisite

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@
 
 PROJECT_NAME=my_drupal8_project
 PROJECT_BASE_URL=drupal.docker.localhost
+PROJECT_ALIAS_URL=drupal2.docker.localhost
 
 DB_NAME=drupal
 DB_USER=drupal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     labels:
       - 'traefik.backend=${PROJECT_NAME}_nginx'
       - 'traefik.port=80'
-      - 'traefik.frontend.rule=Host:${PROJECT_BASE_URL}'
+      - 'traefik.frontend.rule=Host:${PROJECT_BASE_URL},${PROJECT_ALIAS_URL}'
 
   mailhog:
     image: mailhog/mailhog


### PR DESCRIPTION
Here a simple way to enable the multisite Drupal installation for getting 2 URLs to the same Drupal install. 
(As requested many times by the comunity https://github.com/wodby/docker4drupal/issues/299 )

And it doesn't break the install for someone looking for a simple 1 site Drupal install.


