### PR TITLE
Clarify help comment for make drush

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -46,7 +46,8 @@ shell:
 	docker exec -ti -e COLUMNS=$(shell tput cols) -e LINES=$(shell tput lines) $(shell docker ps --filter name='$(PROJECT_NAME)_php' --format "{{ .ID }}") sh
 
 ## drush	:	Executes `drush` command in a specified `DRUPAL_ROOT` directory (default is `/var/www/html/web`).
-## 		Doesn't support --flag arguments.
+##		To use "--flag" arguments include them in quotation marks.
+##		For example: make drush "watchdog:show --type=cron"
 drush:
 	docker exec $(shell docker ps --filter name='^/$(PROJECT_NAME)_php' --format "{{ .ID }}") drush -r $(DRUPAL_ROOT) $(filter-out $@,$(MAKECMDGOALS))
 


### PR DESCRIPTION
To use "--flag" arguments include them in quotation marks.
For example: make drush "watchdog:show --type=cron"