### PR TITLE
Fix make help command in the source code from the latest release

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -8,8 +8,13 @@ COMPOSER_ROOT ?= /var/www/html
 DRUPAL_ROOT ?= /var/www/html/web
 
 ## help	:	Print commands help.
+ifneq (,$(wildcard docker.mk))
 help : docker.mk
 	@sed -n 's/^##//p' $<
+else
+help : Makefile
+	@sed -n 's/^##//p' $<
+endif
 
 ## up	:	Start up containers.
 up:


### PR DESCRIPTION
There is no docker.mk file in the source code from the latest release.
Add check if  docker.mk file exists.