### PR TITLE
Pin Traefik to 1.7.16 to avoid backwards compatibility break from Traefik 2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,7 @@ services:
       - 'traefik.frontend.rule=Host:portainer.${PROJECT_BASE_URL}'
 
   traefik:
-    image: traefik
+    image: traefik:v1.7.16-alpine
     container_name: "${PROJECT_NAME}_traefik"
     command: -c /dev/null --web --docker --logLevel=INFO
     ports:


### PR DESCRIPTION
See https://github.com/wodby/docker4drupal/issues/401 for original issue.

Traefik 2.0 has been released, and introduced non-backwards compatible changes. Since we currently only specify `image: traefik`, Docker4PHP updates the new version and breaks.

This PR pins us to the latest version of Traefik v1 until the larger effort of properly migrating to Traefik v2 can be performed.