### PR TITLE
Include PHP_XDEBUG_IDEKEY: "my-ide"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
 #      PHP_XDEBUG_DEFAULT_ENABLE: 1
 #      PHP_XDEBUG_REMOTE_CONNECT_BACK: 0
 #      PHP_IDE_CONFIG: serverName=my-ide
+#      PHP_XDEBUG_IDEKEY: "my-ide"
 #      PHP_XDEBUG_REMOTE_HOST: host.docker.internal # Docker 18.03+ Mac/Win
 #      PHP_XDEBUG_REMOTE_HOST: 172.17.0.1 # Linux
 #      PHP_XDEBUG_REMOTE_HOST: 10.254.254.254 # macOS, Docker < 18.03


### PR DESCRIPTION
Include PHP_XDEBUG_IDEKEY: "my-ide" to have Xdebug working with the ide NetBeans.