### PR TITLE
Feature request: Introduce DB_PORT environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@ DB_USER=drupal
 DB_PASSWORD=drupal
 DB_ROOT_PASSWORD=password
 DB_HOST=mariadb
+DB_PORT=3306
 DB_DRIVER=mysql
 
 ### --- MARIADB ----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
 #      PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S opensmtpd:25      
       DB_HOST: $DB_HOST
+      DB_PORT: $DB_PORT
       DB_USER: $DB_USER
       DB_PASSWORD: $DB_PASSWORD
       DB_NAME: $DB_NAME


### PR DESCRIPTION
This would be helpful for quick start scripts and help to be able to do like this:

```
cat >> web/sites/default/settings.php << EOL

\$databases['default']['default'] = [
  'database' => getenv('DB_NAME'),
  'username' => getenv('DB_USER'),
  'password' => getenv('DB_PASSWORD'),
  'host' => getenv('DB_HOST'),
  'port' => getenv('DB_PORT'),
  'driver' => getenv('DB_DRIVER'),
];
EOL
```
Affects two files, default value defined to `3306` as DB_HOST value is `mariadb`.