### PR TITLE
:bug: Fix invalid environment variable for pma container.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,8 +147,7 @@ services:
 #      PMA_HOST: $DB_HOST
 #      PMA_USER: $DB_USER
 #      PMA_PASSWORD: $DB_PASSWORD
-#      PHP_UPLOAD_MAX_FILESIZE: 1G
-#      PHP_MAX_INPUT_VARS: 1G
+#      UPLOAD_LIMIT: 1G
 #    labels:
 #      - "traefik.http.routers.${PROJECT_NAME}_pma.rule=Host(`pma.${PROJECT_BASE_URL}`)"
 


### PR DESCRIPTION
The official [phpmyadmin](https://hub.docker.com/r/phpmyadmin/phpmyadmin/) docker image does not have the `PHP_UPLOAD_MAX_FILESIZE` and `PHP_MAX_INPUT_VARS` environment variables. We must use the `UPLOAD_LIMIT` variable to control the maximum size of the uploaded file.