### PR TITLE
Use 'external: true' when settings the networks for Traefik to avoid warnings

### DIFF
--- a/traefik.yml
+++ b/traefik.yml
@@ -15,9 +15,9 @@ services:
 
 networks:
   project1:
-    external: 
-      name: project1-dir_default
+    external: true
+    name: project1-dir_default
   project2:
-    external:
-      name: project2-dir_default
+    external: true
+    name: project2-dir_default
 


### PR DESCRIPTION
**Proposal**

When executing command `docker-compose -f traefik.yml up -d` I'm getting the following warnings:

> WARN[0000] network project1: network.external.name is deprecated. Please set network.name with external: true 
> WARN[0000] network project2: network.external.name is deprecated. Please set network.name with external: true 

This small change should stop showing the error.
