### PR TITLE
Use Compose Specification

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   php:
     image: wodby/drupal:$DRUPAL_TAG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   mariadb:
     image: wodby/mariadb:$MARIADB_TAG

--- a/tests/10/docker-compose.yml
+++ b/tests/10/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mariadb:
     image: wodby/mariadb:$MARIADB_TAG

--- a/tests/7/docker-compose.yml
+++ b/tests/7/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mariadb:
     image: wodby/mariadb:$MARIADB_TAG

--- a/tests/9/docker-compose.yml
+++ b/tests/9/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mariadb:
     image: wodby/mariadb:$MARIADB_TAG

--- a/traefik.yml
+++ b/traefik.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   traefik:
     image: traefik:v2.0


### PR DESCRIPTION
Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It is implemented in versions 1.27.0 and above (also known as Compose V2) of the Docker Compose CLI.

See https://docs.docker.com/compose/compose-file/