### PR TITLE
Change PHP_TAG to version 4.67.0

### DIFF
--- a/.env
+++ b/.env
@@ -36,17 +36,17 @@ DRUPAL_TAG=11-4.96.0
 
 # Linux (uid 1000 gid 1000)
 
-PHP_TAG=8.5-dev-4.79.0
-#PHP_TAG=8.4-dev-4.79.0
-#PHP_TAG=8.3-dev-4.79.0
-#PHP_TAG=8.2-dev-4.79.0
+PHP_TAG=8.5-dev-4.67.0
+#PHP_TAG=8.4-dev-4.67.0
+#PHP_TAG=8.3-dev-4.67.0
+#PHP_TAG=8.2-dev-4.67.0
 
 # macOS (uid 501 gid 20)
 
-#PHP_TAG=8.5-dev-macos-4.79.0
-#PHP_TAG=8.4-dev-macos-4.79.0
-#PHP_TAG=8.3-dev-macos-4.79.0
-#PHP_TAG=8.2-dev-macos-4.79.0
+#PHP_TAG=8.5-dev-macos-4.67.0
+#PHP_TAG=8.4-dev-macos-4.67.0
+#PHP_TAG=8.3-dev-macos-4.67.0
+#PHP_TAG=8.2-dev-macos-4.67.0
 
 ### --- NGINX ----
 


### PR DESCRIPTION
Currently, all PHP tags reference wodby/php at version 4.79.0, which does not exist, leading to an error during image pulling.

```
 Image wodby/php:8.4-dev-4.79.0 Pulling 
 Image wodby/php:8.4-dev-4.79.0 Error manifest for wodby/php:8.4-dev-4.79.0 not found: manifest unknown: manifest unknown
```

Latest version is 4.67.0 → https://github.com/wodby/php/tags

https://hub.docker.com/r/wodby/php/tags?name=8.5-dev-4.67
https://hub.docker.com/r/wodby/php/tags?name=8.5-dev-macos-4.67

--

https://hub.docker.com/r/wodby/php/tags?name=8.5-dev-4.79
https://hub.docker.com/r/wodby/php/tags?name=8.5-dev-macos-4.79
